### PR TITLE
Project Clarity: Parsing overhaul

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,7 @@
   "tasks": {
     "example": "deno run --allow-net --allow-read --allow-write --allow-env=DEBUG ./examples/authentication.ts",
     "test": "deno test --allow-net --allow-read --allow-write --allow-env=DEBUG --fail-fast ./tests/",
+    "test2": "deno test src",
     "npm": "deno run -A ./scripts/npm.ts"
   },
   "lint": {

--- a/deno.lock
+++ b/deno.lock
@@ -1,5 +1,42 @@
 {
   "version": "3",
+  "packages": {
+    "specifiers": {
+      "jsr:@std/assert": "jsr:@std/assert@1.0.3",
+      "jsr:@std/assert@^1.0.3": "jsr:@std/assert@1.0.3",
+      "jsr:@std/expect": "jsr:@std/expect@1.0.1",
+      "jsr:@std/internal@^1.0.2": "jsr:@std/internal@1.0.2",
+      "jsr:@std/testing": "jsr:@std/testing@1.0.1",
+      "npm:@types/node": "npm:@types/node@18.16.19"
+    },
+    "jsr": {
+      "@std/assert@1.0.3": {
+        "integrity": "b0d03ce1ced880df67132eea140623010d415848df66f6aa5df76507ca7c26d8",
+        "dependencies": [
+          "jsr:@std/internal@^1.0.2"
+        ]
+      },
+      "@std/expect@1.0.1": {
+        "integrity": "44075d9c2cb701ddfc4d5a260da2fb26ba3cfd94c45d3a0359f63cabbf85a058",
+        "dependencies": [
+          "jsr:@std/assert@^1.0.3",
+          "jsr:@std/internal@^1.0.2"
+        ]
+      },
+      "@std/internal@1.0.2": {
+        "integrity": "f4cabe2021352e8bfc24e6569700df87bf070914fc38d4b23eddd20108ac4495"
+      },
+      "@std/testing@1.0.1": {
+        "integrity": "9c25841137ee818933e1722091bb9ed5fdc251c35e84c97979a52196bdb6c5c3"
+      }
+    },
+    "npm": {
+      "@types/node@18.16.19": {
+        "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
+        "dependencies": {}
+      }
+    }
+  },
   "redirects": {
     "https://esm.sh/v135/@types/lodash-es@~4.17/index.d.ts": "https://esm.sh/v135/@types/lodash-es@4.17.12/index.d.ts",
     "https://esm.sh/v135/@types/lodash@4.14.202/index": "https://esm.sh/v135/@types/lodash@4.14.202/index~.d.ts"

--- a/examples/authentication.ts
+++ b/examples/authentication.ts
@@ -43,10 +43,9 @@ auth.addEventListener("requires-login", (event) => {
   resolve(auth_flow);
 });
 
-muse.get_library()
-  .then((data) => {
-    return Deno.writeTextFile(
-      "store/library.json",
-      JSON.stringify(data, null, 2),
-    );
-  });
+const data = await muse.get_home();
+
+await Deno.writeTextFile(
+  "store/home.json",
+  JSON.stringify(data, null, 2),
+);

--- a/src/mixins2/browse/home.ts
+++ b/src/mixins2/browse/home.ts
@@ -1,0 +1,13 @@
+import { request_json } from "../../mixins/_request.ts";
+
+import { parse_single_column_browse_results_renderer } from "../../parsers2/tabs/mod.ts";
+
+export async function get_home() {
+  const json = await request_json("browse", {
+    data: { browseId: "FEmusic_home" },
+  });
+
+  const tab = parse_single_column_browse_results_renderer(json.contents).tab;
+
+  return tab;
+}

--- a/src/mixins2/browse/mod.ts
+++ b/src/mixins2/browse/mod.ts
@@ -1,0 +1,1 @@
+export * from "./home.ts";

--- a/src/mixins2/mod.ts
+++ b/src/mixins2/mod.ts
@@ -1,0 +1,1 @@
+export * from "./browse/mod.ts";

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -5,12 +5,4 @@ export * from "./errors.ts";
 export * from "./request.ts";
 export * from "./auth.ts";
 
-export * from "./mixins/browsing.ts";
-export * from "./mixins/explore.ts";
-export * from "./mixins/library.ts";
-export * from "./mixins/playlist.ts";
-export * from "./mixins/queue.ts";
-export * from "./mixins/search.ts";
-export * from "./mixins/uploads.ts";
-
-export type * from "./mixins/utils.ts";
+export * from "./mixins2/mod.ts";

--- a/src/parsers2/chips/_chip_list.test.ts
+++ b/src/parsers2/chips/_chip_list.test.ts
@@ -1,0 +1,26 @@
+import { expect } from "jsr:@std/expect";
+import { describe, it } from "jsr:@std/testing/bdd";
+
+import { _parse_chips_list } from "./_chip_list.ts";
+
+describe("_parse_chips_list", () => {
+  const stub_parser = (t: string) => t;
+
+  it("parses chips", () => {
+    expect(
+      _parse_chips_list(
+        { chipCloudRenderer: { chips: ["hello"] } },
+        stub_parser,
+      )[0],
+    ).toBe("hello");
+  });
+
+  it("produces expected amount of chips", () => {
+    expect(
+      _parse_chips_list(
+        { chipCloudRenderer: { chips: ["hello", "world", "!"] } },
+        stub_parser,
+      ),
+    ).toHaveLength(3);
+  });
+});

--- a/src/parsers2/chips/_chip_list.ts
+++ b/src/parsers2/chips/_chip_list.ts
@@ -1,0 +1,7 @@
+import { Parser, RawJSON } from "../types.d.ts";
+
+export function _parse_chips_list<T>(content: RawJSON, parser: Parser<T>): T[] {
+  const chips = content.chipCloudRenderer.chips;
+
+  return chips.map(parser);
+}

--- a/src/parsers2/chips/chip.test.ts
+++ b/src/parsers2/chips/chip.test.ts
@@ -1,0 +1,59 @@
+import { assert } from "jsr:@std/assert/assert";
+import { expect } from "jsr:@std/expect";
+import { describe, it } from "jsr:@std/testing/bdd";
+
+import { EndpointType } from "../endpoint/mod.ts";
+import { parse_chip } from "./chip.ts";
+import { RawJSON } from "../types.d.ts";
+
+describe("parse_text_runs_simple", () => {
+  const text = { runs: [{ text: "Chip Title" }] };
+
+  function getChip(overrides: RawJSON) {
+    return {
+      chipCloudChipRenderer: {
+        text,
+        isSelected: false,
+        navigationEndpoint: {},
+        ...overrides,
+      },
+    };
+  }
+
+  describe("parses selected", () => {
+    it("parses selected false", () => {
+      expect(
+        parse_chip(getChip({ isSelected: false })).selected,
+      ).toBe(false);
+    });
+
+    it("parses selected false", () => {
+      expect(
+        parse_chip(getChip({ isSelected: true })).selected,
+      ).toBe(true);
+    });
+  });
+
+  it("parses text", () => {
+    expect(
+      parse_chip(getChip({ text: { runs: [{ text: "Hello, World!" }] } })).text,
+    ).toBe("Hello, World!");
+  });
+
+  it("parses navigation", () => {
+    const chip = parse_chip(getChip({
+      navigationEndpoint: {
+        browseEndpoint: {
+          browseId: "BROWSE_ID",
+          params: "PARAMS",
+        },
+      },
+    }));
+
+    assert(chip.navigation.browse, "must parse a browse endpoint");
+
+    expect(
+      chip.navigation.browse.type,
+    ).toBe(EndpointType.BROWSE);
+  });
+});

--- a/src/parsers2/chips/chip.ts
+++ b/src/parsers2/chips/chip.ts
@@ -2,6 +2,7 @@ import { assertEquals } from "jsr:@std/assert";
 
 import { RawJSON } from "../types.d.ts";
 
+import { _parse_chips_list } from "./_chip_list.ts";
 import { parse_endpoint, ParseEndpointResult } from "../endpoint/mod.ts";
 import { parse_text_runs_simple } from "../runs/text_runs_simple.ts";
 
@@ -34,4 +35,8 @@ export function parse_chip(content: RawJSON): ParseChipResult {
     selected,
     navigation: parse_endpoint(chip.navigationEndpoint).endpoints,
   };
+}
+
+export function parse_chips(content: RawJSON) {
+  return _parse_chips_list(content, parse_chip);
 }

--- a/src/parsers2/chips/chip.ts
+++ b/src/parsers2/chips/chip.ts
@@ -1,0 +1,37 @@
+import { assertEquals } from "jsr:@std/assert";
+
+import { RawJSON } from "../types.d.ts";
+
+import { parse_endpoint, ParseEndpointResult } from "../endpoint/mod.ts";
+import { parse_text_runs_simple } from "../runs/text_runs_simple.ts";
+
+export interface ParseChipResult {
+  /**
+   * The text associated with this chip
+   */
+  text: string;
+  /**
+   * Whether this chip is selected or not
+   */
+  selected: boolean;
+  /**
+   * The endpoint to navigate to when this chip is clicked
+   */
+  navigation: ParseEndpointResult["endpoints"];
+}
+
+/**
+ * Parses a chip, usually part of a chipCloud
+ */
+export function parse_chip(content: RawJSON): ParseChipResult {
+  const chip = content.chipCloudChipRenderer;
+  const selected = chip.isSelected;
+
+  assertEquals(typeof selected, "boolean", "the chip must be selected or not");
+
+  return {
+    text: parse_text_runs_simple(chip.text),
+    selected,
+    navigation: parse_endpoint(chip.navigationEndpoint).endpoints,
+  };
+}

--- a/src/parsers2/chips/mod.ts
+++ b/src/parsers2/chips/mod.ts
@@ -1,0 +1,1 @@
+export * from "./chip.ts";

--- a/src/parsers2/chips/mod.ts
+++ b/src/parsers2/chips/mod.ts
@@ -1,1 +1,2 @@
 export * from "./chip.ts";
+export * from "./mood.ts";

--- a/src/parsers2/chips/mooc.test.ts
+++ b/src/parsers2/chips/mooc.test.ts
@@ -1,0 +1,31 @@
+import { expect } from "jsr:@std/expect";
+import { describe, it } from "jsr:@std/testing/bdd";
+
+import { parse_mood_chip } from "./mood.ts";
+
+describe("parse_mood_chip", () => {
+  const parsed = parse_mood_chip({
+    chipCloudChipRenderer: {
+      text: { runs: [{ text: "Mood Chip" }] },
+      isSelected: false,
+      navigationEndpoint: {
+        browseEndpoint: {
+          browseId: "MOOD_BROWSE_ID",
+          params: "MOOD_PARAMS",
+        },
+      },
+    },
+  });
+
+  it("parses title", () => {
+    expect(parsed.text).toBe("Mood Chip")
+  });
+
+  it("parses selected", () => {
+    expect(parsed.selected).toBe(false)
+  });
+
+  it("parses params", () => {
+    expect(parsed.params).toBe("MOOD_PARAMS")
+  });
+});

--- a/src/parsers2/chips/mood.ts
+++ b/src/parsers2/chips/mood.ts
@@ -1,0 +1,27 @@
+import { assert } from "jsr:@std/assert/assert";
+import { RawJSON } from "../types.d.ts";
+
+import { parse_chip } from "./chip.ts";
+import { _parse_chips_list } from "./_chip_list.ts";
+
+export interface ParseMoodChipResult {
+  text: string;
+  selected: boolean;
+  params: string;
+}
+
+export function parse_mood_chip(content: RawJSON): ParseMoodChipResult {
+  const chip = parse_chip(content);
+
+  assert(chip.navigation.browse?.params, "mood chip must have browseId");
+
+  return {
+    text: chip.text,
+    selected: chip.selected,
+    params: chip.navigation.browse.params,
+  };
+}
+
+export function parse_mood_chips(content: RawJSON) {
+  return _parse_chips_list(content, parse_mood_chip);
+}

--- a/src/parsers2/continuations/continuations.test.ts
+++ b/src/parsers2/continuations/continuations.test.ts
@@ -1,0 +1,25 @@
+import { expect } from "jsr:@std/expect";
+import { describe, it } from "jsr:@std/testing/bdd";
+
+import { parse_continuations } from "./continuations.ts";
+
+describe("parse_continuations", () => {
+  const parsed = parse_continuations({
+    continuations: [
+      { nextContinuationData: { continuation: "NEXT_CONTINUATION" } },
+      { reloadContinuationData: { continuation: "RELOAD_CONTINUATION" } },
+    ],
+  });
+
+  it("parses next continuation", () => {
+    expect(parsed.nextContinuation).toBe("NEXT_CONTINUATION");
+  });
+
+  it("parses reload continuation", () => {
+    expect(parsed.reloadContinuation).toBe("RELOAD_CONTINUATION");
+  });
+
+  it("does not parse undefined continuation", () => {
+    expect(parsed.undefinedContinuation).toBeUndefined();
+  });
+});

--- a/src/parsers2/continuations/continuations.ts
+++ b/src/parsers2/continuations/continuations.ts
@@ -1,0 +1,29 @@
+import { RawJSON } from "../types.d.ts";
+
+export type ParseContinuationsResult = Record<string, string>;
+
+/**
+ * Parse an object with continuations
+ */
+export function parse_continuations(content: RawJSON): ParseContinuationsResult {
+  const continuations: ParseContinuationsResult = {};
+
+  for (const continuation of content.continuations) {
+    /**
+     * A continuation has the following syntax:
+     *
+     * {
+     *   "nextContinuationData": {
+     *     "continuation": "..."
+     *   }
+     * }
+     */
+    const name = Object.keys(continuation)[0];
+    const value = continuation[name].continuation;
+
+    if (!name.endsWith("Data")) continue;
+    continuations[name.slice(undefined, -4)] = value;
+  }
+
+  return continuations;
+}

--- a/src/parsers2/continuations/moc.ts
+++ b/src/parsers2/continuations/moc.ts
@@ -1,0 +1,1 @@
+export * from "./continuations.ts";

--- a/src/parsers2/endpoint/endpoints/browse.test.ts
+++ b/src/parsers2/endpoint/endpoints/browse.test.ts
@@ -1,0 +1,23 @@
+import { expect } from "jsr:@std/expect";
+import { describe, it } from "jsr:@std/testing/bdd";
+
+import { parseBrowseEndpoint } from "./browse.ts";
+import { EndpointType } from "../parse.ts";
+
+export const sampleBrowseEndpoint = {
+  browseId: "SOME_BROWSE_ID",
+};
+
+describe("browseEndpoint", () => {
+  const parsed = parseBrowseEndpoint(sampleBrowseEndpoint);
+
+  it("has correct type", () => {
+    expect(parsed.type).toBe(EndpointType.BROWSE);
+  });
+
+  it("parses ID", () => {
+    expect(
+      parseBrowseEndpoint({ browseId: "SOME_BROWSE_ID" }).id,
+    ).toBe("SOME_BROWSE_ID");
+  });
+});

--- a/src/parsers2/endpoint/endpoints/browse.test.ts
+++ b/src/parsers2/endpoint/endpoints/browse.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "jsr:@std/expect";
 import { describe, it } from "jsr:@std/testing/bdd";
 
-import { parseBrowseEndpoint } from "./browse.ts";
+import { parse_browse_endpoint } from "./browse.ts";
 import { EndpointType } from "../parse.ts";
 
 export const sampleBrowseEndpoint = {
@@ -9,7 +9,7 @@ export const sampleBrowseEndpoint = {
 };
 
 describe("browseEndpoint", () => {
-  const parsed = parseBrowseEndpoint(sampleBrowseEndpoint);
+  const parsed = parse_browse_endpoint(sampleBrowseEndpoint);
 
   it("has correct type", () => {
     expect(parsed.type).toBe(EndpointType.BROWSE);
@@ -17,7 +17,16 @@ describe("browseEndpoint", () => {
 
   it("parses ID", () => {
     expect(
-      parseBrowseEndpoint({ browseId: "SOME_BROWSE_ID" }).id,
-    ).toBe("SOME_BROWSE_ID");
+      parse_browse_endpoint(sampleBrowseEndpoint),
+    ).toHaveProperty("id", "SOME_BROWSE_ID");
+  });
+
+  it("parses params", () => {
+    expect(
+      parse_browse_endpoint({
+        browseId: "SOME_BROWSE_ID",
+        params: "SOME_PARAMS",
+      }),
+    ).toHaveProperty("params", "SOME_PARAMS");
   });
 });

--- a/src/parsers2/endpoint/endpoints/browse.ts
+++ b/src/parsers2/endpoint/endpoints/browse.ts
@@ -1,0 +1,27 @@
+import { RawJSON } from "../../types.d.ts";
+
+import { EndpointType } from "../mod.ts";
+import { BaseEndpoint } from "../types.d.ts";
+
+/**
+ * An endpoint the user can navigate to
+ */
+export interface BrowseEndpoint extends BaseEndpoint {
+  type: EndpointType.BROWSE;
+  /**
+   * The ID to use while navigating
+   */
+  id: string;
+}
+
+/**
+ * Parses a browse endpoint
+ * @param content JSON
+ * @returns
+ */
+export function parseBrowseEndpoint(content: RawJSON): BrowseEndpoint {
+  return {
+    type: EndpointType.BROWSE,
+    id: content.browseId,
+  };
+}

--- a/src/parsers2/endpoint/endpoints/browse.ts
+++ b/src/parsers2/endpoint/endpoints/browse.ts
@@ -12,6 +12,10 @@ export interface BrowseEndpoint extends BaseEndpoint {
    * The ID to use while navigating
    */
   id: string;
+  /**
+   * Optional params, usually used to get more data of a specific kind
+   */
+  params?: string;
 }
 
 /**
@@ -19,9 +23,10 @@ export interface BrowseEndpoint extends BaseEndpoint {
  * @param content JSON
  * @returns
  */
-export function parseBrowseEndpoint(content: RawJSON): BrowseEndpoint {
+export function parse_browse_endpoint(content: RawJSON): BrowseEndpoint {
   return {
     type: EndpointType.BROWSE,
     id: content.browseId,
+    params: content.params,
   };
 }

--- a/src/parsers2/endpoint/endpoints/mod.ts
+++ b/src/parsers2/endpoint/endpoints/mod.ts
@@ -1,0 +1,1 @@
+export * from "./browse.ts";

--- a/src/parsers2/endpoint/mod.ts
+++ b/src/parsers2/endpoint/mod.ts
@@ -1,0 +1,3 @@
+export * from "./endpoints/mod.ts";
+export * from "./parse.ts";
+export * from "./types.d.ts";

--- a/src/parsers2/endpoint/parse.test.ts
+++ b/src/parsers2/endpoint/parse.test.ts
@@ -1,0 +1,18 @@
+import { expect } from "jsr:@std/expect";
+import { describe, it } from "jsr:@std/testing/bdd";
+
+import { parseEndpoint } from "./parse.ts";
+
+import { sampleBrowseEndpoint } from "./endpoints/browse.test.ts";
+
+describe("parseEndpoint", () => {
+  it("has `endpoints` key", () => {
+    expect(parseEndpoint({})).toHaveProperty("endpoints");
+  });
+
+  it("parses the browseEndpoint", () => {
+    expect(
+      parseEndpoint({ browseEndpoint: sampleBrowseEndpoint }).endpoints,
+    ).toHaveProperty("browse");
+  });
+});

--- a/src/parsers2/endpoint/parse.test.ts
+++ b/src/parsers2/endpoint/parse.test.ts
@@ -1,18 +1,18 @@
 import { expect } from "jsr:@std/expect";
 import { describe, it } from "jsr:@std/testing/bdd";
 
-import { parseEndpoint } from "./parse.ts";
+import { parse_endpoint } from "./parse.ts";
 
 import { sampleBrowseEndpoint } from "./endpoints/browse.test.ts";
 
 describe("parseEndpoint", () => {
   it("has `endpoints` key", () => {
-    expect(parseEndpoint({})).toHaveProperty("endpoints");
+    expect(parse_endpoint({})).toHaveProperty("endpoints");
   });
 
   it("parses the browseEndpoint", () => {
     expect(
-      parseEndpoint({ browseEndpoint: sampleBrowseEndpoint }).endpoints,
+      parse_endpoint({ browseEndpoint: sampleBrowseEndpoint }).endpoints,
     ).toHaveProperty("browse");
   });
 });

--- a/src/parsers2/endpoint/parse.ts
+++ b/src/parsers2/endpoint/parse.ts
@@ -1,0 +1,42 @@
+import { RawJSON } from "../types.d.ts";
+import { BaseEndpointMap, KnownEndpointName } from "./types.d.ts";
+
+import { parseBrowseEndpoint } from "./endpoints/browse.ts";
+import { KnownEndpoint } from "./types.d.ts";
+
+export const _endpointMap = {
+  "browse": parseBrowseEndpoint,
+} satisfies BaseEndpointMap;
+
+export enum EndpointType {
+  BROWSE,
+}
+
+type EndpointResult<T extends KnownEndpointName> = ReturnType<
+  typeof _endpointMap[T]
+>;
+
+type ParsedEndpoints = {
+  [endpoint in KnownEndpointName]: EndpointResult<"browse">;
+};
+
+export interface ParseEndpointResult {
+  endpoints: Partial<ParsedEndpoints>;
+}
+
+export function parseEndpoint(content: RawJSON): ParseEndpointResult {
+  const endpointEntries = Object.entries(_endpointMap)
+    .map(([name, parser]) => {
+      const endpoint = content[name + "Endpoint"];
+      if (!endpoint) return [name, null] as const;
+      return [name, parser(endpoint)] as const;
+    })
+    .filter(([, parsed]) => !!parsed);
+
+  const endpoints = Object.fromEntries(endpointEntries) as Record<
+    KnownEndpointName,
+    KnownEndpoint
+  >;
+
+  return { endpoints };
+}

--- a/src/parsers2/endpoint/parse.ts
+++ b/src/parsers2/endpoint/parse.ts
@@ -1,11 +1,11 @@
 import { RawJSON } from "../types.d.ts";
 import { BaseEndpointMap, KnownEndpointName } from "./types.d.ts";
 
-import { parseBrowseEndpoint } from "./endpoints/browse.ts";
+import { parse_browse_endpoint } from "./endpoints/browse.ts";
 import { KnownEndpoint } from "./types.d.ts";
 
 export const _endpointMap = {
-  "browse": parseBrowseEndpoint,
+  "browse": parse_browse_endpoint,
 } satisfies BaseEndpointMap;
 
 export enum EndpointType {
@@ -24,7 +24,7 @@ export interface ParseEndpointResult {
   endpoints: Partial<ParsedEndpoints>;
 }
 
-export function parseEndpoint(content: RawJSON): ParseEndpointResult {
+export function parse_endpoint(content: RawJSON): ParseEndpointResult {
   const endpointEntries = Object.entries(_endpointMap)
     .map(([name, parser]) => {
       const endpoint = content[name + "Endpoint"];

--- a/src/parsers2/endpoint/types.d.ts
+++ b/src/parsers2/endpoint/types.d.ts
@@ -1,0 +1,17 @@
+import type { Parser } from "../types.d.ts";
+import { _endpointMap } from "./parse.ts";
+
+import { EndpointType } from "./mod.ts";
+import type { BrowseEndpoint } from "./endpoints/browse.ts";
+
+type EndpointMap = typeof _endpointMap;
+
+export type KnownEndpointName = keyof EndpointMap;
+
+export type BaseEndpointMap = Record<string, Parser<KnownEndpoint>>;
+
+export type KnownEndpoint = BrowseEndpoint;
+
+export interface BaseEndpoint {
+  type: EndpointType;
+}

--- a/src/parsers2/list/mod.ts
+++ b/src/parsers2/list/mod.ts
@@ -1,0 +1,1 @@
+export * from "./section.ts";

--- a/src/parsers2/list/section.test.ts
+++ b/src/parsers2/list/section.test.ts
@@ -1,0 +1,28 @@
+import { expect } from "jsr:@std/expect";
+import { describe, it } from "jsr:@std/testing/bdd";
+
+import { parse_section_list } from "./section.ts";
+
+describe("parse_section_list", () => {
+  const parsed = parse_section_list({
+    sectionListRenderer: {
+      header: "SECTION_LIST_HEADER",
+      contents: "SECTION_LIST_CONTENTS",
+      continuations: [
+        { nextContinuationData: { continuation: "SECTION_LIST_CONTINUATION" } },
+      ],
+    },
+  });
+
+  it("parses header", () => {
+    expect(parsed.header).toBe("SECTION_LIST_HEADER");
+  });
+
+  it("parses contents", () => {
+    expect(parsed.contents).toBe("SECTION_LIST_CONTENTS");
+  });
+
+  it("parses next continuation", () => {
+    expect(parsed.nextContinuation).toBe("SECTION_LIST_CONTINUATION");
+  });
+});

--- a/src/parsers2/list/section.ts
+++ b/src/parsers2/list/section.ts
@@ -1,0 +1,20 @@
+import { RawJSON } from "../types.d.ts";
+
+import { parse_continuations } from "../continuations/moc.ts";
+
+export interface ParseSectionListResult {
+  header: RawJSON;
+  contents: RawJSON[];
+  nextContinuation: string | null;
+}
+
+export function parse_section_list(content: RawJSON): ParseSectionListResult {
+  const section_list = content.sectionListRenderer;
+  const nextContinuation = parse_continuations(section_list).nextContinuation;
+
+  return {
+    header: section_list.header,
+    contents: section_list.contents,
+    nextContinuation: nextContinuation ?? null,
+  };
+}

--- a/src/parsers2/runs/text_runs_simple.test.ts
+++ b/src/parsers2/runs/text_runs_simple.test.ts
@@ -1,0 +1,18 @@
+import { expect } from "jsr:@std/expect";
+import { describe, it } from "jsr:@std/testing/bdd";
+
+import { parse_text_runs_simple } from "./text_runs_simple.ts";
+
+describe("parse_text_runs_simple", () => {
+  it("parses", () => {
+    expect(
+      parse_text_runs_simple({
+        runs: [
+          {
+            text: "Hello, World!",
+          },
+        ],
+      }),
+    ).toBe("Hello, World!");
+  });
+});

--- a/src/parsers2/runs/text_runs_simple.ts
+++ b/src/parsers2/runs/text_runs_simple.ts
@@ -1,0 +1,19 @@
+import { RawJSON } from "../types.d.ts";
+
+/**
+ * Parses text runs into a simple string
+ * 
+ * @example
+ * 
+ * ```ts
+ * const text = parse_text_runs_simple({
+ *  runs: [
+ *    { text: "String" }
+ *  ],
+ * });
+ * expect(text).toBe("String");
+ * ```
+ */
+export function parse_text_runs_simple(content: RawJSON) {
+  return content.runs[0].text;
+}

--- a/src/parsers2/tabs/mod.ts
+++ b/src/parsers2/tabs/mod.ts
@@ -1,0 +1,2 @@
+export * from "./single_column.ts";
+export * from "./tab_renderer.ts";

--- a/src/parsers2/tabs/single_column.test.ts
+++ b/src/parsers2/tabs/single_column.test.ts
@@ -1,0 +1,19 @@
+import { expect } from "jsr:@std/expect";
+import { describe, it } from "jsr:@std/testing/bdd";
+
+import { parse_single_column_browse_results_renderer } from "./single_column.ts";
+import { sampleTab } from "./tab_renderer.test.ts";
+
+describe("parse_single_column_browse_results_renderer", () => {
+  const result = parse_single_column_browse_results_renderer({
+    singleColumnBrowseResultsRenderer: {
+      tabs: [
+        sampleTab,
+      ],
+    },
+  });
+
+  it("parses tab", () => {
+    expect(result).toHaveProperty("tab");
+  });
+});

--- a/src/parsers2/tabs/single_column.ts
+++ b/src/parsers2/tabs/single_column.ts
@@ -1,0 +1,19 @@
+import { j } from "../../util.ts";
+import { RawJSON } from "../types.d.ts";
+
+import { ParseTabRendererResult } from "./tab_renderer.ts";
+import { parse_tab_renderer } from "./tab_renderer.ts";
+
+export interface ParseSingleColumnBrowseResultsRendererResult {
+  tab: ParseTabRendererResult;
+}
+
+export function parse_single_column_browse_results_renderer(
+  content: RawJSON,
+): ParseSingleColumnBrowseResultsRendererResult {
+  const tab = j(content, "singleColumnBrowseResultsRenderer", "tabs", "0");
+
+  return {
+    tab: parse_tab_renderer(tab),
+  };
+}

--- a/src/parsers2/tabs/tab_renderer.test.ts
+++ b/src/parsers2/tabs/tab_renderer.test.ts
@@ -1,0 +1,32 @@
+import { expect } from "jsr:@std/expect";
+import { describe, it } from "jsr:@std/testing/bdd";
+
+import { parse_tab_renderer } from "./tab_renderer.ts";
+
+export const sampleTab = {
+  tabRenderer: {
+    endpoint: {
+      browseEndpoint: {
+        browseId: "PSCBR_ID",
+      },
+    },
+    title: "PSCBR Title",
+    content: "Hello",
+  },
+};
+
+describe("parse_tab_renderer", () => {
+  const result = parse_tab_renderer(sampleTab);
+
+  it("parses browseId", () => {
+    expect(result.browseId).toBe("PSCBR_ID");
+  });
+
+  it("parses title", () => {
+    expect(result.title).toBe("PSCBR Title");
+  });
+
+  it("parses content", () => {
+    expect(result.content).toBe("Hello");
+  });
+});

--- a/src/parsers2/tabs/tab_renderer.ts
+++ b/src/parsers2/tabs/tab_renderer.ts
@@ -1,0 +1,33 @@
+import { assert, assertEquals } from "jsr:@std/assert";
+
+import { RawJSON } from "../types.d.ts";
+
+import { parseEndpoint } from "../endpoint/mod.ts";
+
+export interface ParseTabRendererResult {
+  browseId: string;
+  title: string;
+  content: RawJSON;
+}
+
+export function parse_tab_renderer(content: RawJSON): ParseTabRendererResult {
+  const tab = content.tabRenderer;
+  const browseEndpoint = parseEndpoint(tab.endpoint).endpoints.browse;
+
+  assert(
+    browseEndpoint,
+    "singleColumnBrowseResultsRenderer must have a browseId",
+  );
+
+  const { title } = tab;
+
+  // assertions
+  assertEquals(typeof title, "string", "Tab must have a title");
+  assert(tab.content, "Tab must have content");
+
+  return {
+    browseId: browseEndpoint.id,
+    title,
+    content: tab.content,
+  };
+}

--- a/src/parsers2/tabs/tab_renderer.ts
+++ b/src/parsers2/tabs/tab_renderer.ts
@@ -2,7 +2,7 @@ import { assert, assertEquals } from "jsr:@std/assert";
 
 import { RawJSON } from "../types.d.ts";
 
-import { parseEndpoint } from "../endpoint/mod.ts";
+import { parse_endpoint } from "../endpoint/mod.ts";
 
 export interface ParseTabRendererResult {
   browseId: string;
@@ -12,7 +12,7 @@ export interface ParseTabRendererResult {
 
 export function parse_tab_renderer(content: RawJSON): ParseTabRendererResult {
   const tab = content.tabRenderer;
-  const browseEndpoint = parseEndpoint(tab.endpoint).endpoints.browse;
+  const browseEndpoint = parse_endpoint(tab.endpoint).endpoints.browse;
 
   assert(
     browseEndpoint,

--- a/src/parsers2/thumbnail/background.test.ts
+++ b/src/parsers2/thumbnail/background.test.ts
@@ -1,0 +1,23 @@
+import { expect } from "jsr:@std/expect";
+import { describe, it } from "jsr:@std/testing/bdd";
+
+import { sampleThumbnail } from "./thumbnails.test.ts";
+
+import { parse_background } from "./background.ts";
+
+describe("parse_background", () => {
+  it("parses thumbnails", () => {
+    const thumbnails = [sampleThumbnail];
+    expect(
+      parse_background({
+        background: {
+          musicThumbnailRenderer: {
+            thumbnail: {
+              thumbnails,
+            },
+          },
+        },
+      }).thumbnails,
+    ).toEqual(thumbnails);
+  });
+});

--- a/src/parsers2/thumbnail/background.ts
+++ b/src/parsers2/thumbnail/background.ts
@@ -1,0 +1,14 @@
+import { RawJSON } from "../types.d.ts";
+import { parse_thumbnails } from "./thumbnails.ts";
+
+import { Thumbnail } from "./types.d.ts";
+
+export interface ParseBackgroundResult {
+  thumbnails: Thumbnail[];
+}
+
+export function parse_background(content: RawJSON): ParseBackgroundResult {
+  return {
+    thumbnails: parse_thumbnails(content.background.musicThumbnailRenderer),
+  };
+}

--- a/src/parsers2/thumbnail/mod.ts
+++ b/src/parsers2/thumbnail/mod.ts
@@ -1,0 +1,3 @@
+export * from "./types.d.ts";
+export * from "./background.ts";
+export * from "./thumbnails.ts";

--- a/src/parsers2/thumbnail/thumbnails.test.ts
+++ b/src/parsers2/thumbnail/thumbnails.test.ts
@@ -1,0 +1,30 @@
+import { expect } from "jsr:@std/expect";
+import { describe, it } from "jsr:@std/testing/bdd";
+
+import { parse_thumbnails } from "./thumbnails.ts";
+
+export const sampleThumbnail = {
+  url: "THUMBNAIL_URL",
+  width: 200,
+  height: 100,
+};
+
+describe("parse_thumbnails", () => {
+  it("parses a thumbnail", () => {
+    expect(
+      parse_thumbnails({
+        thumbnail: {
+          thumbnails: [sampleThumbnail],
+        },
+      })[0],
+    ).toBeTruthy();
+  });
+
+  it("parses a number of thumbnails", () => {
+    expect(parse_thumbnails({
+      thumbnail: {
+        thumbnails: [sampleThumbnail, sampleThumbnail, sampleThumbnail],
+      },
+    })).toHaveLength(3);
+  });
+});

--- a/src/parsers2/thumbnail/thumbnails.ts
+++ b/src/parsers2/thumbnail/thumbnails.ts
@@ -1,0 +1,9 @@
+import { RawJSON } from "../types.d.ts";
+
+import { Thumbnail } from "./types.d.ts";
+
+export type ParseThumbnailsResult = Thumbnail[];
+
+export function parse_thumbnails(content: RawJSON): ParseThumbnailsResult {
+  return content.thumbnail.thumbnails;
+}

--- a/src/parsers2/thumbnail/types.d.ts
+++ b/src/parsers2/thumbnail/types.d.ts
@@ -1,0 +1,5 @@
+export interface Thumbnail {
+  url: string;
+  width: string;
+  height: number;
+}

--- a/src/parsers2/types.d.ts
+++ b/src/parsers2/types.d.ts
@@ -1,0 +1,3 @@
+export type RawJSON = any;
+
+export type Parser<T> = (content: RawJSON) => T;

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,6 +2,8 @@ import { JSONPath, JSONPathOptions } from "./deps.ts";
 import { ERROR_CODE, MuseError } from "./errors.ts";
 import { get_option } from "./setup.ts";
 
+type JPathJSON = JSONPathOptions["json"];
+
 /**
  * Wait a given number of milliseconds, then resolve
  */
@@ -20,7 +22,7 @@ export const jom = (
   path: string,
   resultType?: JSONPathOptions["resultType"],
 ): any => {
-  const result = JSONPath({ path, json, resultType });
+  const result = JSONPath({ path, json: json as JPathJSON, resultType });
   return result.length ? result : null;
 };
 export const jo = (
@@ -28,7 +30,10 @@ export const jo = (
   path: string,
   ...others: string[]
 ): any => {
-  const result = JSONPath({ path: [path, ...others].join("."), json });
+  const result = JSONPath({
+    path: [path, ...others].join("."),
+    json: json as JPathJSON,
+  });
   return result.length ? result[0] : null;
 };
 export const j = (json: unknown, path: string, ...others: string[]) => {

--- a/src/util/cache-fetch.ts
+++ b/src/util/cache-fetch.ts
@@ -42,7 +42,7 @@ export async function cache_fetch(url: string, options: RequestInit) {
       await Deno.mkdir("store/cache", { recursive: true });
       await Deno.writeTextFile(
         cache_path,
-        JSON.stringify(await response.clone().json()),
+        JSON.stringify(await response.clone().json(), null, 2),
       );
     } catch {
       // not json probably: ignore


### PR DESCRIPTION
Hello everyone, I'm launching Project Clarity, which will be a major rewrite of the application and will probably lead to our first v1 (#2).

There's a couple of reasons, and I'll list a few starting from the most heavy ones:

1. The current way we parse content was inspired by https://github.com/sigma67/ytmusicapi and relies heavily on guesswork. We parse blindly, expecting JSON to have a certain structure, and in the case of errors, we throw a weird error that usually only myself can decode. The new version of muse will "know" about the structure of the various data types provided by YouTube music's API and will parse them accordingly.
2. The current source has no tests :/
3. The current version has poor documentation, and users sometimes get confused.
4. The current version has many exported symbols, which makes the library users confused.
5. You can find the same parsers implemented many times elsewhere
6. The `nav.ts` file is getting too huge imo, and is almost incomprehensible