### PR TITLE
Fix json import

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,25 @@
+name: Run Unit Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Lint
+        run: deno lint

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -12,9 +12,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: Get tag version
         if: startsWith(github.ref, 'refs/tags/')

--- a/deno.json
+++ b/deno.json
@@ -6,6 +6,7 @@
   },
   "lint": {
     "rules": {
+      "include": ["no-import-assertions"],
       "exclude": ["no-explicit-any"]
     }
   }

--- a/scripts/locales/strings.ts
+++ b/scripts/locales/strings.ts
@@ -5,7 +5,7 @@ import { request_json } from "../../src/mixins/_request.ts";
 import { set_option } from "../../src/mod.ts";
 import { setup } from "../../src/setup.ts";
 import { DenoFileStore } from "../../src/store.ts";
-import { j, jo, jom } from "../../src/util.ts";
+import { jo, jom } from "../../src/util.ts";
 import { cache_fetch } from "../../src/util/cache-fetch.ts";
 
 setup({
@@ -210,7 +210,7 @@ export const fetch_map: FetchMapItem[] = [
   },
 ];
 
-let base_strings = new Map();
+const base_strings = new Map();
 
 async function get_language_map() {
   const map = new Map<string, [uri: string, path: string]>();

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,4 +1,4 @@
-import CONSTANTS from "./constants-ng.json" assert { type: "json" };
+import CONSTANTS from "./constants-ng.json" with { type: "json" };
 import { RequestClient } from "./request.ts";
 import { wait } from "./util.ts";
 import { Store } from "./store.ts";

--- a/src/mixins/_request.ts
+++ b/src/mixins/_request.ts
@@ -1,4 +1,4 @@
-import CONSTANTS2 from "../constants-ng.json" assert { type: "json" };
+import CONSTANTS2 from "../constants-ng.json" with { type: "json" };
 
 import { get_option, set_option } from "../setup.ts";
 

--- a/src/mixins/browsing.ts
+++ b/src/mixins/browsing.ts
@@ -1,4 +1,4 @@
-import CONSTANTS2 from "../constants-ng.json" assert { type: "json" };
+import CONSTANTS2 from "../constants-ng.json" with { type: "json" };
 
 import { get_continuations, get_sort_continuations } from "../continuations.ts";
 import {

--- a/src/parsers/browsing.ts
+++ b/src/parsers/browsing.ts
@@ -1,4 +1,4 @@
-import STRINGS from "../../locales/strings.json" assert { type: "json" };
+import STRINGS from "../../locales/strings.json" with { type: "json" };
 import { LikeStatus } from "../mod.ts";
 import { TAB_CONTENT } from "../nav.ts";
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,5 +1,5 @@
 import { ERROR_CODE, MuseError } from "./errors.ts";
-import LOCALES from "../locales/locales.json" assert { type: "json" };
+import LOCALES from "../locales/locales.json" with { type: "json" };
 import { get_option } from "./setup.ts";
 
 import { debug } from "./util.ts";


### PR DESCRIPTION
With Node 23, using the `assert` keyword throws error and `with` should be used instead. See https://nodejs.org/docs/latest-v23.x/api/esm.html#import-attributes

- [x] Fixing the remaining Deno lint issues.
- [x] Adding a Deno lint GitHub workflow.