### PR TITLE
Fix issue TypeError: Cannot read properties of undefined (reading 'runs') at Module.get_playlist

### DIFF
--- a/src/mixins/playlist.ts
+++ b/src/mixins/playlist.ts
@@ -179,7 +179,7 @@ export async function get_playlist(
     thumbnails: j(header, THUMBNAILS),
     description: jo(header, "description", DESCRIPTION_SHELF, DESCRIPTION),
     type: run_count > 0 ? j(header, SUBTITLE) : null,
-    authors: parse_song_artists_runs(header.straplineTextOne.runs),
+    authors: parse_song_artists_runs(header.straplineTextOne?.runs),
     year: j(header, "subtitle.runs", (run_count - 1).toString(), "text"),
     trackCount: secondRuns ? secondRuns[0].text : null,
     duration: secondRuns && secondRuns.length > 2 ? secondRuns[2].text : null,

--- a/src/parsers/songs.ts
+++ b/src/parsers/songs.ts
@@ -121,7 +121,7 @@ export interface Run {
 }
 
 export function parse_song_artists_runs(runs: Run[] | undefined) {
-  if (!Array.isArray(runs)) {
+  if (!runs || !Array.isArray(runs)) {
     return [];
   }
   const artists: ArtistRun[] = [];

--- a/src/parsers/songs.ts
+++ b/src/parsers/songs.ts
@@ -115,7 +115,7 @@ export interface ArtistRun {
   type: "artist" | "channel";
 }
 
-export function parse_song_artists_runs(runs) {
+export function parse_song_artists_runs(runs: any) {
   if (!runs)
     return [];
   const artists = [];

--- a/src/parsers/songs.ts
+++ b/src/parsers/songs.ts
@@ -115,27 +115,22 @@ export interface ArtistRun {
   type: "artist" | "channel";
 }
 
-export function parse_song_artists_runs(runs: any) {
-  const artists: ArtistRun[] = [];
-  const result = Array(Math.floor(runs.length / 2) + 1).fill(undefined).map((
-    _,
-    index,
-  ) => index);
-
+export function parse_song_artists_runs(runs) {
+  if (!runs)
+    return [];
+  const artists = [];
+  const result = Array(Math.floor(runs.length / 2) + 1).fill(undefined).map((_, index) => index);
   for (const i of result) {
     const run = runs[i * 2];
-
-    if (run == null) continue;
-
+    if (run == null)
+      continue;
     const page_type = jo(run, NAVIGATION_PAGE_TYPE);
-
     artists.push({
       name: run.text,
       id: jo(run, NAVIGATION_BROWSE_ID),
       type: page_type === "MUSIC_PAGE_TYPE_ARTIST" ? "artist" : "channel",
     });
   }
-
   return artists;
 }
 

--- a/src/parsers/songs.ts
+++ b/src/parsers/songs.ts
@@ -116,8 +116,9 @@ export interface ArtistRun {
 }
 
 export function parse_song_artists_runs(runs: any) {
-  if (!runs)
+  if (!runs) {
     return [];
+  }
   const artists: ArtistRun[] = [];
   const result = Array(Math.floor(runs.length / 2) + 1).fill(undefined).map((_, index) => index);
   for (const i of result) {

--- a/src/parsers/songs.ts
+++ b/src/parsers/songs.ts
@@ -121,7 +121,7 @@ export interface Run {
 }
 
 export function parse_song_artists_runs(runs: Run[] | undefined) {
-  if (!runs) {
+  if (!Array.isArray(runs)) {
     return [];
   }
   const artists: ArtistRun[] = [];

--- a/src/parsers/songs.ts
+++ b/src/parsers/songs.ts
@@ -118,7 +118,7 @@ export interface ArtistRun {
 export function parse_song_artists_runs(runs: any) {
   if (!runs)
     return [];
-  const artists = [];
+  const artists: ArtistRun[] = [];
   const result = Array(Math.floor(runs.length / 2) + 1).fill(undefined).map((_, index) => index);
   for (const i of result) {
     const run = runs[i * 2];

--- a/src/parsers/songs.ts
+++ b/src/parsers/songs.ts
@@ -128,7 +128,7 @@ export function parse_song_artists_runs(runs: Run[] | undefined) {
   // Iterate through every other element in 'runs' because each artist entry is located at even indices.
   for (let i = 0; i < runs.length; i += 2) {
     const run = runs[i];
-    if (run == null)
+    if (run === null || run === undefined)
       continue;
     const page_type = jo(run, NAVIGATION_PAGE_TYPE);
     artists.push({

--- a/src/parsers/songs.ts
+++ b/src/parsers/songs.ts
@@ -115,7 +115,12 @@ export interface ArtistRun {
   type: "artist" | "channel";
 }
 
-export function parse_song_artists_runs(runs: any) {
+export interface Run {
+  text: string;
+  [key: string]: any; // Allow additional properties for flexibility
+}
+
+export function parse_song_artists_runs(runs: Run[] | undefined) {
   if (!runs) {
     return [];
   }

--- a/src/parsers/songs.ts
+++ b/src/parsers/songs.ts
@@ -125,6 +125,7 @@ export function parse_song_artists_runs(runs: Run[] | undefined) {
     return [];
   }
   const artists: ArtistRun[] = [];
+  // Iterate through every other element in 'runs' because each artist entry is located at even indices.
   for (let i = 0; i < runs.length; i += 2) {
     const run = runs[i];
     if (run == null)

--- a/src/parsers/songs.ts
+++ b/src/parsers/songs.ts
@@ -120,9 +120,8 @@ export function parse_song_artists_runs(runs: any) {
     return [];
   }
   const artists: ArtistRun[] = [];
-  const result = Array(Math.floor(runs.length / 2) + 1).fill(undefined).map((_, index) => index);
-  for (const i of result) {
-    const run = runs[i * 2];
+  for (let i = 0; i < runs.length; i += 2) {
+    const run = runs[i];
     if (run == null)
       continue;
     const page_type = jo(run, NAVIGATION_PAGE_TYPE);

--- a/src/parsers/songs.ts
+++ b/src/parsers/songs.ts
@@ -115,12 +115,7 @@ export interface ArtistRun {
   type: "artist" | "channel";
 }
 
-export interface Run {
-  text: string;
-  [key: string]: any; // Allow additional properties for flexibility
-}
-
-export function parse_song_artists_runs(runs: Run[] | undefined) {
+export function parse_song_artists_runs(runs: any) {
   if (!runs || !Array.isArray(runs)) {
     return [];
   }


### PR DESCRIPTION
I was having an issue with the get_playlist method of this library, after getting some playlist from the get_home method when I was trying to get the details of the playlist it gave me this error: `TypeError: Cannot read properties of undefined (reading 'runs') at Module.get_playlist (file:///Users/myUser/myProject/node_modules/libmuse/esm/src/mixins/playlist.js:57:66)`.
This pull request makes improvements to error handling and code readability in the playlist and song parsing functionality. The most notable changes include adding safety checks to prevent runtime errors and simplifying the `parse_song_artists_runs` function.

### Error Handling Improvements:
* [`src/mixins/playlist.ts`](diffhunk://#diff-0cc23683173bab36bb73912fa4e84229adb24656515edc85a84b4095975ecf2bL182-R182): Updated the `authors` property in the `get_playlist` function to use optional chaining (`?.`) when accessing `runs` to prevent potential runtime errors if `straplineTextOne` is undefined.
* [`src/parsers/songs.ts`](diffhunk://#diff-67b5e15dc32cf3684718e8c768df4c84b376667db03964a404e2eed17d4890dbL118-L138): Added a null check at the beginning of the `parse_song_artists_runs` function to return an empty array if `runs` is falsy, ensuring the function handles invalid input gracefully.

### Code Readability Enhancements:
* [`src/parsers/songs.ts`](diffhunk://#diff-67b5e15dc32cf3684718e8c768df4c84b376667db03964a404e2eed17d4890dbL118-L138): Removed unnecessary whitespace and simplified the loop structure in the `parse_song_artists_runs` function for better readability.